### PR TITLE
Shallow fetch the project template

### DIFF
--- a/src/workers/gh_client.coffee
+++ b/src/workers/gh_client.coffee
@@ -125,7 +125,7 @@ c =
         else
           return Promise.reject(err)
       ).then(() ->
-        exec('git pull "' + gh_conf.TEMPLATE_REPO + '"', {cwd: TEMPLATE_DIR})
+        exec('git pull --depth=1 "' + gh_conf.TEMPLATE_REPO + '"', {cwd: TEMPLATE_DIR})
       ).then(() ->
         push_repo_url = get_authenticated_repo_url(repo_data.clone_url)
         exec('git push "' + push_repo_url + '" master', {cwd: TEMPLATE_DIR})


### PR DESCRIPTION
Not sure what the first commit message will look like if you accept this change. Might be better to straight up download the files into the folder (rather than fetching or cloning), then make an "Initial commit".
